### PR TITLE
Docker planetary-graphql

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,4 +13,6 @@ COPY . .
 EXPOSE  4000
 EXPOSE 26835
 
-CMD ["npm", "start", "index.js"]
+RUN npm install pm2 -g
+
+CMD ["pm2-runtime", "index.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM node:16
+
+WORKDIR /app
+
+COPY package*.json ./
+
+RUN npm update
+
+RUN npm install
+
+COPY . .
+
+EXPOSE  4000
+EXPOSE 26835
+
+CMD ["npm", "start", "index.js"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+---
+version: '2.2'
+services:
+  graphql:
+    image: zachboyofdestiny/planetary-graphql:1.0
+    environment:
+      - DB_PATH=/tmp/planetary-graphql
+      - ROOM_HOST=$GO_SSB_ROOM_DOMAIN
+      - ROOM_URL=https://$GO_SSB_ROOM_DOMAIN
+      - ROOM_PORT=8008
+      - ROOM_KEY= $SSBKEY_OF_GO_SSB_ROOM
+      - MAGIC_TOKEN=3vdWyLACyrKtzdveenWq9wbbPXh1Aq-Ds7VcUMX6kE27mW9K4k4a3tPFjE_Cjz_9rYA=
+      - LOGGING=false
+      - BLOBS_URL=http://0.0.0.0:26835
+    ports:
+      - "4000:4000" # the graphql endpoint
+      - "0.0.0.0:26835:26835" # the blob server
+    restart: "on-failure"
+    volumes:
+      - ./db:/tmp/planetary-graphql


### PR DESCRIPTION
This PR adds a Dockerfile for building planetary-graphql as a docker image, for easier compatibility with ansible scripts.

NOTE: This generally works, but is an incredible memory hog.  I am uncertain whether the memory issues were due to the build or the app.  The dockerfile is meant to follow the deploy instructions in the README as close as possible, but there may be issues in the base image I used or some such.  I wanted to offer the PR as a stake in the ground, but would love to pair on looking at graphql's memory usage further.