### PR TITLE
Serve blobs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       - MAGIC_TOKEN=3vdWyLACyrKtzdveenWq9wbbPXh1Aq-Ds7VcUMX6kE27mW9K4k4a3tPFjE_Cjz_9rYA=
       - LOGGING=false
       - NODE_ENV=production
-      - BLOBS_URL=http://0.0.0.0:26835
+      - BLOBS_URL=/blob/
     ports:
       - "4000:4000" # the graphql endpoint
       - "0.0.0.0:26835:26835" # the blob server

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ services:
       - ROOM_KEY= $SSBKEY_OF_GO_SSB_ROOM
       - MAGIC_TOKEN=3vdWyLACyrKtzdveenWq9wbbPXh1Aq-Ds7VcUMX6kE27mW9K4k4a3tPFjE_Cjz_9rYA=
       - LOGGING=false
+      - NODE_ENV=production
       - BLOBS_URL=http://0.0.0.0:26835
     ports:
       - "4000:4000" # the graphql endpoint


### PR DESCRIPTION
This PR brings some necessary updates to the docker-compose.yml to properly serve blobs.

NOTE: this  file is not used in our actual deployment (that is handled by https://github.com/planetary-social/ansible-scripts/pull/20.  But if you are wanting to run the graphql as a container locally, this file helps with that.