### PR TITLE
get threads for members

### DIFF
--- a/src/graphql/resolvers.js
+++ b/src/graphql/resolvers.js
@@ -175,6 +175,46 @@ module.exports = function Resolvers (ssb) {
   }
 
   /**
+   * Gets all the public threads that room members have posted or replied to
+   * @param {object} opts - optional parameters
+   * @param {int} [opts.limit=10] - max amount of threads to return
+   * @param {int} opts.threadMaxSize - max amount of messages in each thread to return
+   */
+  const getPublicThreads = (opts) => {
+    const { threadMaxSize, limit = 10 } = opts
+    
+    const members = ssb.room.members()
+      
+    return new Promise((resolve, reject) => {
+      pull(
+        ssb.threads.public({ threadMaxSize, allowlist: ['post'], following: true }),
+        // this could be more optimised
+        // it handles cases where in early development stages, the graphql servers were following 
+        // some ssb users when syncing. This has been removed, but some databases (like mine)
+        // still have those users, so it will mess with the display a little 
+        pull.filter(thread => {
+          return thread.messages.some(message => {
+            return members.includes(message.value?.author)
+          })
+        }),
+        pull.take(limit),
+        pull.collect((err, threads) => {
+          if (err) return reject(err)
+
+          const res = threads.map(({ messages }) => {
+            return {
+              id: messages[0].key,
+              messages
+            }
+          })
+
+          resolve(res)
+        })
+      )
+    })
+  }
+
+  /**
    * Takes a messages and maps it either to a Comment or "empty" Comment depending on
    * whether the author has opted into publicWebHosting.
    * @param {object} msg - a post message in kv format
@@ -247,7 +287,13 @@ module.exports = function Resolvers (ssb) {
 
         return getProfile(alias.userId)
       },
-      getInviteCode: () => getRoomInviteCode()
+      getInviteCode: () => getRoomInviteCode(),
+
+      getThreads: (_, opts = {}) => {
+        return opts.id
+          ? getThreads(opts.id, opts)
+          : getPublicThreads(opts)
+      }
     },
     Profile: {
       image: (parent) => {
@@ -339,7 +385,7 @@ module.exports = function Resolvers (ssb) {
         return notices
           ?.find(notice => notice.language === parent.language)
           ?.content
-      },
+      }
       // TODO: other notices include:
       // - [ ] NoticeCodeOfConduct
       // - [ ] NoticeNews

--- a/src/graphql/typeDefs.js
+++ b/src/graphql/typeDefs.js
@@ -62,9 +62,15 @@ module.exports = gql`
     gets the peers who have opted into publicWebHosting
     """
     getProfiles(limit: Int): [Profile]
-    
 
+  
     # getThread(id: ID!, preview: Boolean): Thread
+
+    """
+    gets the threads by a member when an id is provided,
+    or all public threads by members up to a limit (default limit is 10)
+    """
+    getThreads(id: ID, limit: Int, maxThreadSize: Int): [Thread]
 
     """
     get a detail on the room you paired with this api server


### PR DESCRIPTION
This adds a getThreads query. When there is no id, it will load public threads where members have posted/responded. I decided to write it as a separate query, instead of incorporating it into the rooms query so it doesnt hold up any loading of room information. This will also make it easier when we add pagination input to this query!