### PR TITLE
Create github action for building/pushing images

### DIFF
--- a/.github/workflows/build-push.yaml
+++ b/.github/workflows/build-push.yaml
@@ -2,7 +2,7 @@ name: Create and publish Docker image
 
 on:
   push:
-    branches: ['master']
+    branches: ['main']
 
 env:
   IMAGE_NAME: ${{ github.repository }}

--- a/.github/workflows/build-push.yaml
+++ b/.github/workflows/build-push.yaml
@@ -1,0 +1,44 @@
+name: Create and publish Docker image
+
+on:
+  push:
+    branches: ['master']
+
+env:
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v2.1.0
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: cooldracula/planetary-graphql
+          # generate Docker tags based on the following events/attributes
+          tags: |
+            type=raw,value=latest
+            type=raw,value=stable
+            type=sha,enable=true,prefix={{date 'YYYYMMDD'}}_sha-,format=short
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v4.0.0
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Similar to [go-ssb-room pr#11](https://github.com/planetary-social/go-ssb-room/pull/11), this adds a github action for the automatic building and pushing of images to a docker repository.  It is meant as a starting point, so that we can iterate improvements to our pipeline.

[You can see the action in action on my forked repo](https://github.com/cooldracula/planetary-graphql/actions/runs/4289436132)